### PR TITLE
use phpseclib 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     }
   ],
   "require": {
-    "phpseclib/phpseclib": "~0.3"
+    "phpseclib/phpseclib": "2.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0"

--- a/lib/openpgp_crypt_rsa.php
+++ b/lib/openpgp_crypt_rsa.php
@@ -7,7 +7,11 @@
  */
 
 // From http://phpseclib.sourceforge.net/
-require_once 'Crypt/RSA.php';
+use phpseclib\Crypt\RSA as Crypt_RSA;
+use phpseclib\Math\BigInteger as Math_BigInteger;
+
+define('CRYPT_RSA_ENCRYPTION_PKCS1', Crypt_RSA::ENCRYPTION_PKCS1);
+define('CRYPT_RSA_SIGNATURE_PKCS1', Crypt_RSA::SIGNATURE_PKCS1);
 
 require_once dirname(__FILE__).'/openpgp.php';
 @include_once dirname(__FILE__).'/openpgp_crypt_symmetric.php'; /* For encrypt/decrypt */

--- a/lib/openpgp_crypt_symmetric.php
+++ b/lib/openpgp_crypt_symmetric.php
@@ -1,20 +1,24 @@
 <?php
 
+use phpseclib\Crypt\TripleDES as Crypt_TripleDES;
+use phpseclib\Crypt\AES as Crypt_AES;
+use phpseclib\Crypt\Random;
+
+define('CRYPT_DES_MODE_CFB', Crypt_TripleDES::MODE_CFB);
+define('CRYPT_AES_MODE_CFB', Crypt_AES::MODE_CFB);
+
 require_once dirname(__FILE__).'/openpgp.php';
 @include_once dirname(__FILE__).'/openpgp_crypt_rsa.php';
 @include_once dirname(__FILE__).'/openpgp_mcrypt_wrapper.php';
-@include_once 'Crypt/AES.php';
-@include_once 'Crypt/TripleDES.php';
-require_once 'Crypt/Random.php'; // part of phpseclib is absolutely required
 
 class OpenPGP_Crypt_Symmetric {
   public static function encrypt($passphrases_and_keys, $message, $symmetric_algorithm=9) {
     list($cipher, $key_bytes, $key_block_bytes) = self::getCipher($symmetric_algorithm);
     if(!$cipher) throw new Exception("Unsupported cipher");
-    $prefix = crypt_random_string($key_block_bytes);
+    $prefix = Random::string($key_block_bytes);
     $prefix .= substr($prefix, -2);
 
-    $key = crypt_random_string($key_bytes);
+    $key = Random::string($key_bytes);
     $cipher->setKey($key);
 
     $to_encrypt = $prefix . $message->to_bytes();
@@ -36,7 +40,7 @@ class OpenPGP_Crypt_Symmetric {
         $esk = pack('n', OpenPGP::bitlength($esk)) . $esk;
         array_unshift($encrypted, new OpenPGP_AsymmetricSessionKeyPacket($pass->algorithm, $pass->fingerprint(), $esk));
       } else if(is_string($pass)) {
-        $s2k = new OpenPGP_S2K(crypt_random_string(10));
+        $s2k = new OpenPGP_S2K(Random::string(10));
         $cipher->setKey($s2k->make_key($pass, $key_bytes));
         $esk = $cipher->encrypt(chr($symmetric_algorithm) . $key);
         array_unshift($encrypted, new OpenPGP_SymmetricSessionKeyPacket($s2k, $esk, $symmetric_algorithm));
@@ -143,11 +147,9 @@ class OpenPGP_Crypt_Symmetric {
     $cipher = NULL;
     switch($algo) {
       case 2:
-        if(class_exists('Crypt_TripleDES')) {
           $cipher = new Crypt_TripleDES(CRYPT_DES_MODE_CFB);
           $key_bytes = 24;
           $key_block_bytes = 8;
-        }
         break;
       case 3:
         if(defined('MCRYPT_CAST_128')) {
@@ -155,22 +157,16 @@ class OpenPGP_Crypt_Symmetric {
         }
         break;
       case 7:
-        if(class_exists('Crypt_AES')) {
           $cipher = new Crypt_AES(CRYPT_AES_MODE_CFB);
           $cipher->setKeyLength(128);
-        }
         break;
       case 8:
-        if(class_exists('Crypt_AES')) {
           $cipher = new Crypt_AES(CRYPT_AES_MODE_CFB);
           $cipher->setKeyLength(192);
-        }
         break;
       case 9:
-        if(class_exists('Crypt_AES')) {
           $cipher = new Crypt_AES(CRYPT_AES_MODE_CFB);
           $cipher->setKeyLength(256);
-        }
         break;
     }
     if(!$cipher) return array(NULL, NULL, NULL); // Unsupported cipher


### PR DESCRIPTION
As you've requested in https://github.com/singpolyma/openpgp-php/pull/15, I've reset to first commit.

The minimum required version is now 5.3.3, the dependency is set in composer.json of phpseclib, so I didn't add another one to openpgp-php composer.json.