### PR TITLE
Link to new project that uses OpenPGP.php as library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Users
 
 OpenPGP.php is currently being used in the following projects:
 
-* <http://drupal.org/project/openpgp>
+* <https://drupal.org/project/openpgp>
+* <https://wordpress.org/plugins/wp-pgp-encrypted-emails/>
 
 Download
 --------


### PR DESCRIPTION
This also changes the Drupal URL to use `https` instead of `http`.