### PR TITLE
fixed keygen example for the phpseclib 2.0 branch

### DIFF
--- a/examples/keygen.php
+++ b/examples/keygen.php
@@ -3,7 +3,7 @@
 require_once dirname(__FILE__).'/../lib/openpgp.php';
 require_once dirname(__FILE__).'/../lib/openpgp_crypt_rsa.php';
 
-$rsa = new Crypt_RSA();
+$rsa = new \phpseclib\Crypt\RSA();
 $k = $rsa->createKey(512);
 $rsa->loadKey($k['privatekey']);
 


### PR DESCRIPTION
Starting with phpseclib 2.0, it is fully namespaced and we have to use the fully qualified name.