### PR TITLE
use $cipher->key_length

### DIFF
--- a/lib/openpgp_crypt_symmetric.php
+++ b/lib/openpgp_crypt_symmetric.php
@@ -170,7 +170,7 @@ class OpenPGP_Crypt_Symmetric {
         break;
     }
     if(!$cipher) return array(NULL, NULL, NULL); // Unsupported cipher
-    if(!isset($key_bytes)) $key_bytes = $cipher->key_size;
+    if(!isset($key_bytes)) $key_bytes = isset($cipher->key_size)?$cipher->key_size:$cipher->key_length;
     if(!isset($key_block_bytes)) $key_block_bytes = $cipher->block_size;
     return array($cipher, $key_bytes, $key_block_bytes);
   }


### PR DESCRIPTION
starting with phpseclib 2.0.1, `key_size` was renamed to `key_length`