### PR TITLE
added more PHP versions to the travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: php
 php:
-  - "5.4"
-  - "5.3"
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
+  - nightly
 before_script:
   - composer install --prefer-source --dev


### PR DESCRIPTION
5.3 and 5.4 could be possibly removed. Nightly builds and HHVM should be ok.