### PR TITLE
Seems phpseclib 2.0.3 breaks us

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ php:
 #  - nightly
 
 env:
-  - PHPSECLIB="^2.0"
   - PHPSECLIB="2.0.0"
+  - PHPSECLIB="2.0.1"
+  - PHPSECLIB="2.0.2"
 
 before_script: 'sed -i "s/\"phpseclib\/phpseclib\": \"[^\"]*/\"phpseclib\/phpseclib\": \"$PHPSECLIB/" composer.json && composer install --prefer-source --dev'

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     }
   ],
   "require": {
-    "phpseclib/phpseclib": "^2.0"
+    "phpseclib/phpseclib": ">=2.0.0 <2.0.3"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
Restrict dependency versions until the issue is found.

Closes #44 
Closes #42
Closes #37