### PR TITLE
Provide more guidance for understanding the examples.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 language: php
 php:
   - 7.0
@@ -48,4 +49,4 @@ matrix:
     - env: PHPSECLIB="2.0.6"
   fast_finish: true
 
-before_script: 'sed -i "s/\"phpseclib\/phpseclib\": \"[^\"]*/\"phpseclib\/phpseclib\": \"$PHPSECLIB/" composer.json && composer install --prefer-source --dev'
+before_script: 'sed -i "s/\"phpseclib\/phpseclib\": \"[^\"]*/\"phpseclib\/phpseclib\": \"$PHPSECLIB/" composer.json && composer install --prefer-source'

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,22 @@
+OpenPGP.php Examples
+====================
+
+The scripts in this folder show how to use this library to perform various tasks
+such as [generating a new key](keygen.php), [signing a message](sign.php), and
+[verifying a message](verify.php) that has been signed.
+
+To use these examples, make sure [`phpseclib`](http://phpseclib.sourceforge.net/) is available. You can install it
+using [Composer](https://getcomposer.org/):
+
+```sh
+git clone https://github.com/singpolyma/openpgp-php.git # Clone the repository.
+cd openpgp-php
+composer install # Use Composer to install the requirements.
+```
+
+Once Composer has installed the requirements, run the examples using PHP:
+
+```sh
+# Generate a new OpenPGP key; see the `keygen.php` file for parameters.
+php ./examples/keygen.php > mykey.gpg
+```

--- a/examples/clearsign.php
+++ b/examples/clearsign.php
@@ -1,5 +1,6 @@
 <?php
 
+@include_once dirname(__FILE__).'/../vendor/autoload.php';
 require_once dirname(__FILE__).'/../lib/openpgp.php';
 require_once dirname(__FILE__).'/../lib/openpgp_crypt_rsa.php';
 
@@ -27,5 +28,3 @@ echo "-----BEGIN PGP SIGNED MESSAGE-----\nHash: SHA256\n\n";
 // trailing whitespace to lines.
 echo preg_replace("/^-/", "- -",  $packets[0]->data)."\n";
 echo OpenPGP::enarmor($packets[1][0]->to_bytes(), "PGP SIGNATURE");
-
-?>

--- a/examples/deASCIIdeCrypt.php
+++ b/examples/deASCIIdeCrypt.php
@@ -3,6 +3,7 @@
 // USAGE: php examples/deASCIIdeCrypt.php secretkey.asc password message.asc
 // This will fail if the algo on key or message is not 3DES or AES
 
+@include_once dirname(__FILE__).'/../vendor/autoload.php';
 require_once dirname(__FILE__).'/../lib/openpgp.php';
 require_once dirname(__FILE__).'/../lib/openpgp_crypt_rsa.php';
 require_once dirname(__FILE__).'/../lib/openpgp_crypt_symmetric.php';

--- a/examples/encryptDecrypt.php
+++ b/examples/encryptDecrypt.php
@@ -1,5 +1,6 @@
 <?php
 
+@include_once dirname(__FILE__).'/../vendor/autoload.php';
 require_once dirname(__FILE__).'/../lib/openpgp.php';
 require_once dirname(__FILE__).'/../lib/openpgp_crypt_rsa.php';
 require_once dirname(__FILE__).'/../lib/openpgp_crypt_symmetric.php';

--- a/examples/keygen.php
+++ b/examples/keygen.php
@@ -1,5 +1,6 @@
 <?php
 
+@include_once dirname(__FILE__).'/../vendor/autoload.php';
 require_once dirname(__FILE__).'/../lib/openpgp.php';
 require_once dirname(__FILE__).'/../lib/openpgp_crypt_rsa.php';
 

--- a/examples/sign.php
+++ b/examples/sign.php
@@ -1,5 +1,6 @@
 <?php
 
+@include_once dirname(__FILE__).'/../vendor/autoload.php';
 require_once dirname(__FILE__).'/../lib/openpgp.php';
 require_once dirname(__FILE__).'/../lib/openpgp_crypt_rsa.php';
 
@@ -18,5 +19,3 @@ $m = $sign->sign($data);
 
 /* Output the raw message bytes to STDOUT */
 echo $m->to_bytes();
-
-?>

--- a/examples/verify.php
+++ b/examples/verify.php
@@ -1,5 +1,6 @@
 <?php
 
+@include_once dirname(__FILE__).'/../vendor/autoload.php';
 require_once dirname(__FILE__).'/../lib/openpgp.php';
 require_once dirname(__FILE__).'/../lib/openpgp_crypt_rsa.php';
 
@@ -14,5 +15,3 @@ $verify = new OpenPGP_Crypt_RSA($wkey);
 
 /* Dump verification information to STDOUT */
 var_dump($verify->verify($m));
-
-?>


### PR DESCRIPTION
This commit adds an `example/README.md` file with a litle bit of
guidance for running the examples themselves. This is helpful because
the examples all rely on the presence of a `phpseclib` installation
available to the PHP interpreter, and while there is a `composer.json`
file to this effect, none of the examples included the Composer
`autoload.php` file.

This commit makes no modifications to the example code itself, but does
`require_once()` the Composer autoload script so that `phpseclib` loads
and avoids causing a fatal error when a new user attempts to run the
examples to learn how to use the library.