### PR TITLE
Added 8.0 to the supported PHP versions in `composer.json`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     }
   ],
   "require": {
-    "php": "^5.6 || ^7.0",
+    "php": "^5.6 || ^7.0 || ^8.0",
     "phpseclib/phpseclib": "^2.0 !=2.0.8"
   },
   "require-dev": {


### PR DESCRIPTION
Please see the discussion in #107.

This would work best if the `0.x` versions continue to support PHP 5.4 (if desirable), and a new `1.x` release line supports PHP 7.4 and 8.x.

A subsequent PR updates PHPUnit to 9.5 so the tests also run successfully on PHP 8.0. The current version-locked dependency uses the `each()` function, which has been removed.