### PR TITLE
Fix misc minor issues to improve PHP 8.1 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 .tmp
 pkg
 tmp
+composer.lock
+.phpunit.result.cache
+.idea
+vendor/

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "phpunit/phpunit": "^9.0"
   },
   "suggest": {
-    "ext-mcrypt": "required if you use encryption cast5"
+    "ext-mcrypt": "required if you use encryption cast5",
+    "ext-openssl": "required if you use encryption cast5"
   },
   "autoload": {
     "classmap": ["lib/"]

--- a/lib/openpgp.php
+++ b/lib/openpgp.php
@@ -379,24 +379,34 @@ class OpenPGP_Message implements IteratorAggregate, ArrayAccess {
 
   // IteratorAggregate interface
 
+  // function getIterator(): \Traversable { // when php 5 support is dropped
+  #[\ReturnTypeWillChange]
   function getIterator() {
     return new ArrayIterator($this->packets);
   }
 
   // ArrayAccess interface
 
+  // function offsetExists($offset): bool // when php 5 support is dropped
+  #[\ReturnTypeWillChange]
   function offsetExists($offset) {
     return isset($this->packets[$offset]);
   }
 
+  // function offsetGet($offset): mixed // when php 7.4 support is dropped
+  #[\ReturnTypeWillChange]
   function offsetGet($offset) {
     return $this->packets[$offset];
   }
 
+  // function offsetSet($offset, $value): void // when php 5 support is dropped
+  #[\ReturnTypeWillChange]
   function offsetSet($offset, $value) {
-    return is_null($offset) ? $this->packets[] = $value : $this->packets[$offset] = $value;
+    is_null($offset) ? $this->packets[] = $value : $this->packets[$offset] = $value;
   }
 
+  // function offsetUnset($offset): void // when php 5 support is dropped
+  #[\ReturnTypeWillChange]
   function offsetUnset($offset) {
     unset($this->packets[$offset]);
   }
@@ -421,7 +431,7 @@ class OpenPGP_Packet {
 
   /**
    * Parses an OpenPGP packet.
-   * 
+   *
    * Partial body lengths based on https://github.com/toofishes/python-pgpdump/blob/master/pgpdump/packet.py
    *
    * @see http://tools.ietf.org/html/rfc4880#section-4.2
@@ -559,7 +569,7 @@ class OpenPGP_Packet {
    */
   function read_unpacked($count, $format) {
     $unpacked = unpack($format, $this->read_bytes($count));
-    return reset($unpacked);
+    return is_array($unpacked) ? reset($unpacked) : NULL;
   }
 
   function read_byte() {
@@ -1377,6 +1387,9 @@ class OpenPGP_PublicKeyPacket extends OpenPGP_Packet {
         if(strtoupper($p->issuer()) == $keyid16) {
           $sigs[] = $p;
         } else {
+          if(!is_array($p->hashed_subpackets)) {
+              break;
+          }
           foreach(array_merge($p->hashed_subpackets, $p->unhashed_subpackets) as $s) {
             if($s instanceof OpenPGP_SignaturePacket_EmbeddedSignaturePacket && strtoupper($s->issuer()) == $keyid16) {
               $sigs[] = $p;
@@ -1677,25 +1690,33 @@ class OpenPGP_CompressedDataPacket extends OpenPGP_Packet implements IteratorAgg
   }
 
   // IteratorAggregate interface
-
+  // function getIterator(): \Traversable { // when PHP 5 support is dropped
+  #[\ReturnTypeWillChange]
   function getIterator() {
     return new ArrayIterator($this->data->packets);
   }
 
   // ArrayAccess interface
-
+  // function offsetExists($offset): bool {  // when PHP 5 support is dropped
+  #[\ReturnTypeWillChange]
   function offsetExists($offset) {
     return isset($this->data[$offset]);
   }
 
+  // function offsetGet($offset): mixed { // when PHP 7 support is dropped
+  #[\ReturnTypeWillChange]
   function offsetGet($offset) {
     return $this->data[$offset];
   }
 
+  // function offsetSet($offset, $value): void { // when PHP 5 support is dropped
+  #[\ReturnTypeWillChange]
   function offsetSet($offset, $value) {
-    return is_null($offset) ? $this->data[] = $value : $this->data[$offset] = $value;
+    is_null($offset) ? $this->data[] = $value : $this->data[$offset] = $value;
   }
 
+  #[\ReturnTypeWillChange]
+  // function offsetUnset($offset): void { // PHP 5 support is dropped
   function offsetUnset($offset) {
     unset($this->data[$offset]);
   }

--- a/tests/phpseclib_suite.php
+++ b/tests/phpseclib_suite.php
@@ -64,8 +64,19 @@ class KeyVerification extends TestCase {
   }
 }
 
+abstract class LibTestCase extends TestCase {
+  public function assertCast5Support() {
+    if(in_array('mcrypt', get_loaded_extensions())) {
+       return;
+    }
+    if(in_array('cast5-cfb', openssl_get_cipher_methods()) || in_array('CAST5-CFB', openssl_get_cipher_methods())) {
+      return;
+    }
+    $this->markTestSkipped('Not supported');
+  }
+}
 
-class Decryption extends TestCase {
+class Decryption extends LibTestCase {
   public function oneSymmetric($pass, $cnt, $path) {
     $m = OpenPGP_Message::parse(file_get_contents(dirname(__FILE__) . '/data/' . $path));
     $m2 = OpenPGP_Crypt_Symmetric::decryptSymmetric($pass, $m);
@@ -82,6 +93,7 @@ class Decryption extends TestCase {
   }
 
   public function testDecryptCAST5() { // Requires mcrypt or openssl
+    $this->assertCast5Support();
     $this->oneSymmetric("hello", "PGP\n", "symmetric-cast5.gpg");
   }
 
@@ -159,7 +171,7 @@ class Decryption extends TestCase {
   }
 }
 
-class Encryption extends TestCase {
+class Encryption extends LibTestCase {
   public function oneSymmetric($algorithm) {
     $data = new OpenPGP_LiteralDataPacket('This is text.', array('format' => 'u', 'filename' => 'stuff.txt'));
     $encrypted = OpenPGP_Crypt_Symmetric::encrypt('secret', new OpenPGP_Message(array($data)), $algorithm);
@@ -173,6 +185,7 @@ class Encryption extends TestCase {
   }
 
   public function testEncryptSymmetricCAST5() {
+    $this->assertCast5Support();
     $this->oneSymmetric(3);
   }
 


### PR DESCRIPTION
Hello,

This is a pull request to fix some small issues we found when running passbolt testsuite against php8.1.
Mostly:
- PHP8.1 deprecation warning with regards to IteratorAggregate and ArrayAccess interface
- Some array type issues when dealing with some of our specific error scenarios
- A test assertion to skip Cast5 tests as OpenSSL for example doesn't support the CAST5-CFB algorithm anymore on Ubuntu 22.04.

Thank you for your work! 👋 
