### PR TITLE
Fix PHP 8.2 deprecation errors

### DIFF
--- a/.travis.dhall
+++ b/.travis.dhall
@@ -10,7 +10,9 @@ in
 	php = [
 		"7.3",
 		"7.4",
-		"8.0"
+		"8.0",
+		"8.1",
+		"8.2"
 	],
 	dist = "xenial",
 	env = [
@@ -22,7 +24,7 @@ in
 			Prelude.List.map Text Exclusion (\(env: Text) ->
 				{ php = php, env = env }
 			) (phpseclib 7 (\(_: Natural) -> True))
-		) ["7.3", "7.4", "8.0"],
+		) ["7.3", "7.4", "8.0", "8.1", "8.2"],
 		fast_finish = True
 	},
 	before_script = ''

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,81 +2,111 @@
 before_script: "sed -i \"s/\\\"phpseclib\\/phpseclib\\\": \\\"[^\\\"]*/\\\"phpseclib\\/phpseclib\\\": \\\"$PHPSECLIB/\" composer.json && composer install --prefer-source"
 dist: xenial
 env:
-- "PHPSECLIB='^2.0 !=2.0.8'"
-- "PHPSECLIB='2.0.0'"
-- "PHPSECLIB='2.0.1'"
-- "PHPSECLIB='2.0.2'"
-- "PHPSECLIB='2.0.3'"
-- "PHPSECLIB='2.0.4'"
-- "PHPSECLIB='2.0.5'"
-- "PHPSECLIB='2.0.6'"
-- "PHPSECLIB='2.0.7'"
-- "PHPSECLIB='2.0.9'"
-- "PHPSECLIB='2.0.10'"
-- "PHPSECLIB='2.0.11'"
-- "PHPSECLIB='2.0.12'"
-- "PHPSECLIB='2.0.13'"
-- "PHPSECLIB='2.0.14'"
-- "PHPSECLIB='2.0.15'"
-- "PHPSECLIB='2.0.16'"
-- "PHPSECLIB='2.0.17'"
-- "PHPSECLIB='2.0.18'"
-- "PHPSECLIB='2.0.19'"
-- "PHPSECLIB='2.0.20'"
-- "PHPSECLIB='2.0.21'"
-- "PHPSECLIB='2.0.22'"
-- "PHPSECLIB='2.0.23'"
-- "PHPSECLIB='2.0.24'"
-- "PHPSECLIB='2.0.25'"
-- "PHPSECLIB='2.0.26'"
-- "PHPSECLIB='2.0.27'"
+  - "PHPSECLIB='^2.0 !=2.0.8'"
+  - "PHPSECLIB='2.0.0'"
+  - "PHPSECLIB='2.0.1'"
+  - "PHPSECLIB='2.0.2'"
+  - "PHPSECLIB='2.0.3'"
+  - "PHPSECLIB='2.0.4'"
+  - "PHPSECLIB='2.0.5'"
+  - "PHPSECLIB='2.0.6'"
+  - "PHPSECLIB='2.0.7'"
+  - "PHPSECLIB='2.0.9'"
+  - "PHPSECLIB='2.0.10'"
+  - "PHPSECLIB='2.0.11'"
+  - "PHPSECLIB='2.0.12'"
+  - "PHPSECLIB='2.0.13'"
+  - "PHPSECLIB='2.0.14'"
+  - "PHPSECLIB='2.0.15'"
+  - "PHPSECLIB='2.0.16'"
+  - "PHPSECLIB='2.0.17'"
+  - "PHPSECLIB='2.0.18'"
+  - "PHPSECLIB='2.0.19'"
+  - "PHPSECLIB='2.0.20'"
+  - "PHPSECLIB='2.0.21'"
+  - "PHPSECLIB='2.0.22'"
+  - "PHPSECLIB='2.0.23'"
+  - "PHPSECLIB='2.0.24'"
+  - "PHPSECLIB='2.0.25'"
+  - "PHPSECLIB='2.0.26'"
+  - "PHPSECLIB='2.0.27'"
 language: php
 matrix:
   exclude:
-  - env: "PHPSECLIB='2.0.0'"
-    php: '7.3'
-  - env: "PHPSECLIB='2.0.1'"
-    php: '7.3'
-  - env: "PHPSECLIB='2.0.2'"
-    php: '7.3'
-  - env: "PHPSECLIB='2.0.3'"
-    php: '7.3'
-  - env: "PHPSECLIB='2.0.4'"
-    php: '7.3'
-  - env: "PHPSECLIB='2.0.5'"
-    php: '7.3'
-  - env: "PHPSECLIB='2.0.6'"
-    php: '7.3'
-  - env: "PHPSECLIB='2.0.0'"
-    php: '7.4'
-  - env: "PHPSECLIB='2.0.1'"
-    php: '7.4'
-  - env: "PHPSECLIB='2.0.2'"
-    php: '7.4'
-  - env: "PHPSECLIB='2.0.3'"
-    php: '7.4'
-  - env: "PHPSECLIB='2.0.4'"
-    php: '7.4'
-  - env: "PHPSECLIB='2.0.5'"
-    php: '7.4'
-  - env: "PHPSECLIB='2.0.6'"
-    php: '7.4'
-  - env: "PHPSECLIB='2.0.0'"
-    php: '8.0'
-  - env: "PHPSECLIB='2.0.1'"
-    php: '8.0'
-  - env: "PHPSECLIB='2.0.2'"
-    php: '8.0'
-  - env: "PHPSECLIB='2.0.3'"
-    php: '8.0'
-  - env: "PHPSECLIB='2.0.4'"
-    php: '8.0'
-  - env: "PHPSECLIB='2.0.5'"
-    php: '8.0'
-  - env: "PHPSECLIB='2.0.6'"
-    php: '8.0'
+    - env: "PHPSECLIB='2.0.0'"
+      php: '7.3'
+    - env: "PHPSECLIB='2.0.1'"
+      php: '7.3'
+    - env: "PHPSECLIB='2.0.2'"
+      php: '7.3'
+    - env: "PHPSECLIB='2.0.3'"
+      php: '7.3'
+    - env: "PHPSECLIB='2.0.4'"
+      php: '7.3'
+    - env: "PHPSECLIB='2.0.5'"
+      php: '7.3'
+    - env: "PHPSECLIB='2.0.6'"
+      php: '7.3'
+    - env: "PHPSECLIB='2.0.0'"
+      php: '7.4'
+    - env: "PHPSECLIB='2.0.1'"
+      php: '7.4'
+    - env: "PHPSECLIB='2.0.2'"
+      php: '7.4'
+    - env: "PHPSECLIB='2.0.3'"
+      php: '7.4'
+    - env: "PHPSECLIB='2.0.4'"
+      php: '7.4'
+    - env: "PHPSECLIB='2.0.5'"
+      php: '7.4'
+    - env: "PHPSECLIB='2.0.6'"
+      php: '7.4'
+    - env: "PHPSECLIB='2.0.0'"
+      php: '8.0'
+    - env: "PHPSECLIB='2.0.1'"
+      php: '8.0'
+    - env: "PHPSECLIB='2.0.2'"
+      php: '8.0'
+    - env: "PHPSECLIB='2.0.3'"
+      php: '8.0'
+    - env: "PHPSECLIB='2.0.4'"
+      php: '8.0'
+    - env: "PHPSECLIB='2.0.5'"
+      php: '8.0'
+    - env: "PHPSECLIB='2.0.6'"
+      php: '8.0'
+    - env: "PHPSECLIB='2.0.0'"
+      php: '8.1'
+    - env: "PHPSECLIB='2.0.1'"
+      php: '8.1'
+    - env: "PHPSECLIB='2.0.2'"
+      php: '8.1'
+    - env: "PHPSECLIB='2.0.3'"
+      php: '8.1'
+    - env: "PHPSECLIB='2.0.4'"
+      php: '8.1'
+    - env: "PHPSECLIB='2.0.5'"
+      php: '8.1'
+    - env: "PHPSECLIB='2.0.6'"
+      php: '8.1'
+    - env: "PHPSECLIB='2.0.0'"
+      php: '8.2'
+    - env: "PHPSECLIB='2.0.1'"
+      php: '8.2'
+    - env: "PHPSECLIB='2.0.2'"
+      php: '8.2'
+    - env: "PHPSECLIB='2.0.3'"
+      php: '8.2'
+    - env: "PHPSECLIB='2.0.4'"
+      php: '8.2'
+    - env: "PHPSECLIB='2.0.5'"
+      php: '8.2'
+    - env: "PHPSECLIB='2.0.6'"
+      php: '8.2'
   fast_finish: true
 php:
-- '7.3'
-- '7.4'
-- '8.0'
+  - '7.3'
+  - '7.4'
+  - '8.0'
+  - '8.1'
+  - '8.2'

--- a/lib/openpgp.php
+++ b/lib/openpgp.php
@@ -538,7 +538,7 @@ class OpenPGP_Packet {
   }
 
   function header_and_body() {
-    $body = $this->body(); // Get body first, we will need it's length
+    $body = $this->body() ?? ''; // Get body first, we will need it's length
     $tag = chr($this->tag | 0xC0); // First two bits are 1 for new packet format
     $size = chr(255).pack('N', strlen($body)); // Use 5-octet lengths
     return array('header' => $tag.$size, 'body' => $body);
@@ -616,6 +616,10 @@ class OpenPGP_Packet {
 class OpenPGP_AsymmetricSessionKeyPacket extends OpenPGP_Packet {
   public $version, $keyid, $key_algorithm, $encrypted_data;
 
+  public $input;
+
+  public $length;
+
   function __construct($key_algorithm='', $keyid='', $encrypted_data='', $version=3) {
     parent::__construct();
     $this->version = $version;
@@ -664,6 +668,10 @@ class OpenPGP_AsymmetricSessionKeyPacket extends OpenPGP_Packet {
 class OpenPGP_SignaturePacket extends OpenPGP_Packet {
   public $version, $signature_type, $hash_algorithm, $key_algorithm, $hashed_subpackets, $unhashed_subpackets, $hash_head;
   public $trailer; // This is the literal bytes that get tacked on the end of the message when verifying the signature
+
+  public $input;
+
+  public $length;
 
   function __construct($data=NULL, $key_algorithm=NULL, $hash_algorithm=NULL) {
     parent::__construct();
@@ -941,6 +949,10 @@ class OpenPGP_SignaturePacket extends OpenPGP_Packet {
 }
 
 class OpenPGP_SignaturePacket_Subpacket extends OpenPGP_Packet {
+  public $input;
+
+  public $length;
+
   function __construct($data=NULL) {
     parent::__construct($data);
     $this->tag = array_search(substr(substr(get_class($this), 8+16), 0, -6), OpenPGP_SignaturePacket::$subpacket_types);
@@ -1199,6 +1211,8 @@ class OpenPGP_SignaturePacket_PolicyURIPacket extends OpenPGP_SignaturePacket_Su
 }
 
 class OpenPGP_SignaturePacket_KeyFlagsPacket extends OpenPGP_SignaturePacket_Subpacket {
+  public $flags;
+
   function __construct($flags=array()) {
     parent::__construct();
     $this->flags = $flags;
@@ -1286,6 +1300,10 @@ class OpenPGP_SignaturePacket_EmbeddedSignaturePacket extends OpenPGP_SignatureP
 class OpenPGP_SymmetricSessionKeyPacket extends OpenPGP_Packet {
   public $version, $symmetric_algorithm, $s2k, $encrypted_data;
 
+  public $input;
+
+  public $length;
+
   function __construct($s2k=NULL, $encrypted_data='', $symmetric_algorithm=9, $version=3) {
     parent::__construct();
     $this->version = $version;
@@ -1314,6 +1332,11 @@ class OpenPGP_SymmetricSessionKeyPacket extends OpenPGP_Packet {
  */
 class OpenPGP_OnePassSignaturePacket extends OpenPGP_Packet {
   public $version, $signature_type, $hash_algorithm, $key_algorithm, $key_id, $nested;
+
+  public $input;
+
+  public $length;
+
   function read() {
     $this->version = ord($this->read_byte());
     $this->signature_type = ord($this->read_byte());
@@ -1347,6 +1370,10 @@ class OpenPGP_PublicKeyPacket extends OpenPGP_Packet {
   public $version, $timestamp, $algorithm;
   public $key, $key_id, $fingerprint;
   public $v3_days_of_validity;
+
+  public $input;
+
+  public $length;
 
   function __construct($key=array(), $algorithm='RSA', $timestamp=NULL, $version=4) {
     parent::__construct();
@@ -1544,6 +1571,10 @@ class OpenPGP_PublicKeyPacket extends OpenPGP_Packet {
  * @see http://tools.ietf.org/html/rfc4880#section-12
  */
 class OpenPGP_PublicSubkeyPacket extends OpenPGP_PublicKeyPacket {
+  public $input;
+
+  public $length;
+
   // TODO
 }
 
@@ -1642,6 +1673,10 @@ class OpenPGP_CompressedDataPacket extends OpenPGP_Packet implements IteratorAgg
   /* see http://tools.ietf.org/html/rfc4880#section-9.3 */
   static $algorithms = array(0 => 'Uncompressed', 1 => 'ZIP', 2 => 'ZLIB', 3 => 'BZip2');
 
+  public $input;
+
+  public $length;
+
   function __construct($m=NULL, $algorithm=1) {
     parent::__construct();
     $this->algorithm = $algorithm;
@@ -1730,6 +1765,10 @@ class OpenPGP_CompressedDataPacket extends OpenPGP_Packet implements IteratorAgg
  * @see http://tools.ietf.org/html/rfc4880#section-5.7
  */
 class OpenPGP_EncryptedDataPacket extends OpenPGP_Packet {
+  public $input;
+
+  public $length;
+
   function read() {
     $this->data = $this->input;
   }
@@ -1755,6 +1794,10 @@ class OpenPGP_MarkerPacket extends OpenPGP_Packet {
  */
 class OpenPGP_LiteralDataPacket extends OpenPGP_Packet {
   public $format, $filename, $timestamp;
+
+  public $input;
+
+  public $length;
 
   function __construct($data=NULL, $opt=array()) {
     parent::__construct();
@@ -1800,6 +1843,10 @@ class OpenPGP_LiteralDataPacket extends OpenPGP_Packet {
  * @see http://tools.ietf.org/html/rfc4880#section-5.10
  */
 class OpenPGP_TrustPacket extends OpenPGP_Packet {
+  public $input;
+
+  public $length;
+
   function read() {
     $this->data = $this->input;
   }
@@ -1817,6 +1864,10 @@ class OpenPGP_TrustPacket extends OpenPGP_Packet {
  */
 class OpenPGP_UserIDPacket extends OpenPGP_Packet {
   public $name, $comment, $email;
+
+  public $input;
+
+  public $length;
 
   function __construct($name='', $comment='', $email='') {
     parent::__construct();
@@ -1880,6 +1931,10 @@ class OpenPGP_UserIDPacket extends OpenPGP_Packet {
 class OpenPGP_UserAttributePacket extends OpenPGP_Packet {
   public $packets;
 
+  public $input;
+  
+  public $length;
+
   // TODO
 }
 
@@ -1890,6 +1945,10 @@ class OpenPGP_UserAttributePacket extends OpenPGP_Packet {
  */
 class OpenPGP_IntegrityProtectedDataPacket extends OpenPGP_EncryptedDataPacket {
   public $version;
+
+  public $input;
+
+  public $length;
 
   function __construct($data='', $version=1) {
     parent::__construct();


### PR DESCRIPTION
This PR:
1. Fixes deprecation errors related to PHP 8.2
2. ~~Adds PHP 8.1, 8.2 in travis CI matrix~~ Looks like travis is not running(last run was about a year ago). In that case it is good idea to merge [this](https://github.com/singpolyma/openpgp-php/pull/118) open PR and get rid of travis related files altogether.