### PR TITLE
PB-26152 parser support of critical subpacket flag

### DIFF
--- a/lib/openpgp.php
+++ b/lib/openpgp.php
@@ -881,10 +881,16 @@ class OpenPGP_SignaturePacket extends OpenPGP_Packet {
     }
     $input = substr($input, $length_of_length); // Chop off length header
     $tag = ord($input[0]);
+    // Is the subpacket critical?
+    $criticalFlagMask = 0x80;
+    $typeMask = 0x7F;
+    $isCritical = ($tag & $criticalFlagMask) === $criticalFlagMask;
+    $tag = $tag & $typeMask;
     $class = self::class_for($tag);
     if($class) {
       $packet = new $class();
       $packet->tag = $tag;
+      $packet->isCritical = $isCritical;
       $packet->input = substr($input, 1, $len-1);
       $packet->length = $len-1;
       $packet->read();
@@ -950,6 +956,8 @@ class OpenPGP_SignaturePacket extends OpenPGP_Packet {
 
 class OpenPGP_SignaturePacket_Subpacket extends OpenPGP_Packet {
   public $input;
+
+  public $isCritical = false;
 
   public $length;
 
@@ -1932,7 +1940,7 @@ class OpenPGP_UserAttributePacket extends OpenPGP_Packet {
   public $packets;
 
   public $input;
-  
+
   public $length;
 
   // TODO


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new feature to identify critical subpackets in OpenPGP signatures, enhancing security and data integrity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->