### PR TITLE
Uncaught OutOfRangeException: Ciphertext representative out of range

### DIFF
--- a/lib/openpgp_crypt_rsa.php
+++ b/lib/openpgp_crypt_rsa.php
@@ -222,6 +222,8 @@ class OpenPGP_Crypt_RSA {
         $data = $key->decrypt($edata);
     } catch (\RuntimeException $e) {
         return NULL;
+    } catch (\OutOfRangeException $e) {
+        return NULL;
     }
 
     if(!$data) return NULL;


### PR DESCRIPTION
Fixed : PHP Fatal error:  Uncaught OutOfRangeException: Ciphertext representative out of range
https://github.com/singpolyma/openpgp-php/issues/137

I am not pgp expert, used AI to fix this issue.
[Commit](https://github.com/singpolyma/openpgp-php/commit/ccfba41279e31dfae43f465796e2f105a72b7645) Provided by google Jules.  For my error file, I only handled the `OutOfRangeException`, and that resolved the issue