### PR TITLE
Reduce memory usage of S2K iteration

### DIFF
--- a/lib/openpgp.php
+++ b/lib/openpgp.php
@@ -187,9 +187,9 @@ class OpenPGP_S2K {
   }
 
   function iterate($s) {
-    if(strlen($s) >= $this->count) return $s;
-    $s = str_repeat($s, ceil($this->count / strlen($s)));
-    return substr($s, 0, $this->count);
+    $sLen = strlen($s);
+    if($sLen >= $this->count) return $s;
+    return str_repeat($s, floor($this->count / $sLen)) . substr($s, 0, $this->count % $sLen);
   }
 
   function make_key($pass, $size) {


### PR DESCRIPTION
With very large S2K `count` values, creating the key object was using double the memory of the S2K value because it first built a longer-than-needed string and then used `substr` to get only the needed length, which created another new string object.

This PR replaces `str_repeat(..., ceil(...))` (making a too-long string) and `substr` (trimming it) with `str_repeat(..., floor(...))` (making a too-short string) and a different use of `substr` (padding it with the remainder).

fixes #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal string iteration logic for improved efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/singpolyma/openpgp-php/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->